### PR TITLE
Send cmcd data to content steering server

### DIFF
--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -169,7 +169,7 @@ function CmcdModel() {
 
     function _applyWhitelist(cmcdData) {
         try {
-            const cmcdParameters = getCmcdParametersMDP();
+            const cmcdParameters = getCmcdParametersFromManifest();
             let enabledCMCDKeys = settings.get().streaming.cmcd.enabledKeys;
 
             if (cmcdParameters.version) {
@@ -234,12 +234,11 @@ function CmcdModel() {
     }
 
     function isCmcdEnabled() {
-        const cmcdParameters = getCmcdParametersMDP();
-
+        const cmcdParameters = getCmcdParametersFromManifest();
         return cmcdParameters.version ? true : settings.get().streaming.cmcd && settings.get().streaming.cmcd.enabled;
     }
 
-    function getCmcdParametersMDP() {
+    function getCmcdParametersFromManifest() {
         const serviceDescription = serviceDescriptionController.getServiceDescriptionSettings();
         let cmcdParameters = {};
 
@@ -255,7 +254,7 @@ function CmcdModel() {
     }
 
     function _applyWhitelistByKeys(keys) {
-        const cmcdParameters = getCmcdParametersMDP();
+        const cmcdParameters = getCmcdParametersFromManifest();
         let enabledCMCDKeys = settings.get().streaming.cmcd.enabledKeys;
 
         if (cmcdParameters.version) {
@@ -285,12 +284,22 @@ function CmcdModel() {
                 return _getCmcdDataForOther(request);
             } else if (request.type === HTTPRequest.LICENSE) {
                 return _getCmcdDataForLicense(request);
+            } else if (request.type === HTTPRequest.CONTENT_STEERING_TYPE) {
+                return _getCmcdDataForSteering(request);
             }
 
             return cmcdData;
         } catch (e) {
             return null;
         }
+    }
+
+    function _getCmcdDataForSteering() {
+        const data = _getGenericCmcdData();
+
+        data.ot = OBJECT_TYPES.OTHER;
+
+        return data;
     }
 
     function _getCmcdDataForLicense(request) {
@@ -428,7 +437,7 @@ function CmcdModel() {
 
 
     function _getGenericCmcdData() {
-        const cmcdParameters = getCmcdParametersMDP();
+        const cmcdParameters = getCmcdParametersFromManifest();
         const data = {};
 
         let cid = settings.get().streaming.cmcd.cid ? settings.get().streaming.cmcd.cid : internalData.cid;
@@ -660,7 +669,7 @@ function CmcdModel() {
     instance = {
         getQueryParameter,
         getHeaderParameters,
-        getCmcdParametersMDP,
+        getCmcdParametersFromManifest,
         setConfig,
         reset,
         initialize,

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -307,7 +307,7 @@ function HTTPLoader(cfg) {
         let headers = null;
         let modifiedUrl = requestModifier.modifyRequestURL ? requestModifier.modifyRequestURL(request.url) : request.url;
         if (cmcdModel.isCmcdEnabled()) {
-            const cmcdParameters = cmcdModel.getCmcdParametersMDP();
+            const cmcdParameters = cmcdModel.getCmcdParametersFromManifest();
             const cmcdMode = cmcdParameters.mode ? cmcdParameters.mode : settings.get().streaming.cmcd.mode;
             if (cmcdMode === Constants.CMCD_MODE_QUERY) {
                 const additionalQueryParameter = _getAdditionalQueryParameter(request);

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -818,7 +818,7 @@ function ProtectionController(config) {
      */
     function _doLicenseRequest(request, retriesCount, timeout, onLoad, onAbort, onError) {
         const xhr = new XMLHttpRequest();
-        const cmcdParameters = cmcdModel.getCmcdParametersMDP();
+        const cmcdParameters = cmcdModel.getCmcdParametersFromManifest();
 
         if (cmcdModel.isCmcdEnabled()) {
             const cmcdMode = cmcdParameters.mode ? cmcdParameters.mode : settings.get().streaming.cmcd.mode;


### PR DESCRIPTION
- Created a new case in `CmcdModel` for content steering to send the Cmcd generic data. 

Pending in next step:
- Investigate what other data apart of the generic data could be sent to steering server. 

![image](https://github.com/qualabs/dash.js/assets/37405481/842bcf9d-f6b4-4304-a5da-bf1d3d05cf47)

![image](https://github.com/qualabs/dash.js/assets/37405481/78f5cbdf-ef8f-4e7c-821c-b69b06bbd6b1)
