### PR TITLE
Border case on steering value set as includeInRequest

### DIFF
--- a/src/streaming/models/ClientDataReportingModel.js
+++ b/src/streaming/models/ClientDataReportingModel.js
@@ -29,6 +29,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 import FactoryMaker from '../../core/FactoryMaker';
+import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 
 function ClientDataReportingModel() {
 
@@ -43,19 +44,19 @@ function ClientDataReportingModel() {
         }
     }
 
-    function serviceLocationIncluded(serviceLocation){
+    function serviceLocationIncluded(requestType, serviceLocation){
+
+        if(requestType == HTTPRequest.CONTENT_STEERING_TYPE)
+            return true;
+
         const { serviceLocationsArray } = serviceDescriptionController?.getServiceDescriptionSettings()?.clientDataReporting ?? {};
-
         const isServiceLocationIncluded = serviceLocationsArray ? (serviceLocationsArray?.length === 0 || serviceLocationsArray.includes(serviceLocation)) : true;
-
         return isServiceLocationIncluded;
     }
 
     function adaptationSetIncluded(adaptationSet){
         const { adaptationSetsArray } = serviceDescriptionController?.getServiceDescriptionSettings()?.clientDataReporting ?? {};
-
         const isAdaptationsIncluded = adaptationSetsArray ? (adaptationSetsArray?.length === 0 || adaptationSetsArray.includes(adaptationSet)) : true;
-
         return isAdaptationsIncluded;
     }
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -309,9 +309,10 @@ function HTTPLoader(cfg) {
 
         let headers = null;
         let modifiedUrl = requestModifier.modifyRequestURL ? requestModifier.modifyRequestURL(request.url) : request.url;
-        const currentServiceLocation = request?.serviceLocation;
+        
+        const currentServiceLocation = request?.serviceLocation; 
         const currentAdaptationSetId = request?.mediaInfo?.id?.toString();
-        const isIncludedFilters = clientDataReportingModel.serviceLocationIncluded(currentServiceLocation) && clientDataReportingModel.adaptationSetIncluded(currentAdaptationSetId);
+        const isIncludedFilters = clientDataReportingModel.serviceLocationIncluded(request.type, currentServiceLocation) && clientDataReportingModel.adaptationSetIncluded(currentAdaptationSetId);
         if (isIncludedFilters && cmcdModel.isCmcdEnabled()) {
             const cmcdParameters = cmcdModel.getCmcdParametersFromManifest();
             const cmcdMode = cmcdParameters.mode ? cmcdParameters.mode : settings.get().streaming.cmcd.mode;


### PR DESCRIPTION
Observation:
We understand that when ‘steering’ is set in includeInRequests, the CMCD data will always be sent to the content steering server regardless of the server location filter. Because server locations are related to the CDNs and the content steering server is an independent server which does not need to be under a cdn domain.

Expected behavior:  The CMCD data will be sent just for the requests sent to the content steering server (includeInRequests=’steering’).

![image](https://github.com/qualabs/dash.js/assets/8515648/34f868b0-22b1-4ee5-b184-d86fcc94460e)

![image](https://github.com/qualabs/dash.js/assets/8515648/07a0ba22-c495-4843-b5c7-6f5bcc420202)