### PR TITLE
[CMCD-v2]: State interval mode

### DIFF
--- a/docs/cmcd-v2/reporting-modes.md
+++ b/docs/cmcd-v2/reporting-modes.md
@@ -10,3 +10,8 @@ Here are notes about the challenge of implementing the new reporting modes of CM
     - The mode that already exists in the configuration for the "transmition mode" might be confusing with the new mode for the "reporting mode".
 
     - The ‘ts’ key is not entirely accurate since the CMCD parameters are generated before the request starts.
+
+
+### State-Interval Mode
+
+- Should the state be set to rebuffering when the video buffer gets stalled? or also the audio buffer?

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -56,7 +56,7 @@
                             responseMode: {
                                 enabled: true, /* enable cmcdv2 response mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
-                                enabledKeys: ['sid', 'cid', 'br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
+                                enabledKeys: ['sid', 'cid', 'br', 'd', 'ot', 'tb', 'v'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_response_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
                             },
@@ -64,7 +64,7 @@
                                 enabled: true, /* enable cmcdv2 state-interval mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
                                 interval: 10000,  /* time in ms between regular requests. Default 30s or 0 to omit */
-                                enabledKeys: ['sid', 'cid', 'v', 'sf'], /* optional, overrides global keys */
+                                enabledKeys: ['sta', 'sid', 'cid', 'sf', 'v'], /* Currently only supports: 'sta', 'sid', 'cid', 'sf', 'v', 'lb', 'pr' */
                                 requestUrl: 'http://localhost:3000/cmcd_state_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST',  /* optional, get by default */
                             }

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -54,12 +54,19 @@
                                 mode: CMCD_MODE_HEADER, /*overrides global mode */
                             },
                             responseMode: {
-                                enabled: true, /* enable cmcdv2 response mode */
+                                enabled: false, /* enable cmcdv2 response mode */
                                 mode: CMCD_MODE_QUERY, /*overrides global mode */
                                 enabledKeys: ['br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
                                 requestHeaders: {} /*optional, additional headers for report request */
+                            },
+                            stateIntervalMode: {
+                                enabled: true,
+                                interval: 10000, // 10 seconds
+                                requestUrl: 'http://localhost:3000/cmcd_state',
+                                requestMethod: 'POST',
+                                enabledKeys: ['br', 'd', 'ot', 'tb']
                             }
                         },
                         sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5', /* session id send with each request */

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -50,7 +50,7 @@
                         version: 2, /* 1 is the default version */
                         reporting: {
                             requestMode: {
-                                enabled: false, /* enable cmcdv2 request mode */
+                                enabled: true, /* enable cmcdv2 request mode */
                                 mode: CMCD_MODE_HEADER, /* overrides global mode */
                             },
                             responseMode: {

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -64,7 +64,7 @@
                                 enabled: true, /* enable cmcdv2 state-interval mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
                                 interval: 10000,  /* time in ms between regular requests. Default 30s or 0 to omit */
-                                enabledKeys: ['sid', 'v', 'sf'], /* optional, overrides global keys */
+                                enabledKeys: ['sid', 'cid', 'v', 'sf'], /* optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_state_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST',  /* optional, get by default */
                             }

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -54,19 +54,12 @@
                                 mode: CMCD_MODE_HEADER, /*overrides global mode */
                             },
                             responseMode: {
-                                enabled: false, /* enable cmcdv2 response mode */
+                                enabled: true, /* enable cmcdv2 response mode */
                                 mode: CMCD_MODE_QUERY, /*overrides global mode */
                                 enabledKeys: ['br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
                                 requestHeaders: {} /*optional, additional headers for report request */
-                            },
-                            stateIntervalMode: {
-                                enabled: true,
-                                interval: 10000, // 10 seconds
-                                requestUrl: 'http://localhost:3000/cmcd_state',
-                                requestMethod: 'POST',
-                                enabledKeys: ['br', 'd', 'ot', 'tb']
                             }
                         },
                         sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5', /* session id send with each request */

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -50,13 +50,13 @@
                         version: 2, /* 1 is the default version */
                         reporting: {
                             requestMode: {
-                                enabled: true, /* enable cmcdv2 request mode */
+                                enabled: false, /* enable cmcdv2 request mode */
                                 mode: CMCD_MODE_HEADER, /* overrides global mode */
                             },
                             responseMode: {
                                 enabled: true, /* enable cmcdv2 response mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
-                                enabledKeys: ['sid', 'cid', 'br', 'd', 'ot', 'tb', 'v'], /*optional, overrides global keys */
+                                //enabledKeys: ['sid', 'cid', 'br', 'd', 'ot', 'tb', 'v', 'sta'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_response_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
                             },
@@ -72,7 +72,7 @@
                         sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5', /* session id send with each request */
                         cid: '21cf726cfe3d937b5f974f72bb5bd06a', /* content id send with each request */
                         mode: CMCD_MODE_QUERY, /* global mode if not specified in each mode */
-                        enabledKeys: ['br', 'd', 'ot', 'tb' , 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su' , 'bs', 'rtp' , 'cid', 'pr', 'sf', 'sid', 'st', 'v']
+                        enabledKeys: ['br', 'd', 'ot', 'tb' , 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su' , 'bs', 'rtp' , 'cid', 'pr', 'sf', 'sid', 'st', 'v', 'sta', 'ltc', 'msd']
                     }
                 }
             });

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -51,23 +51,23 @@
                         reporting: {
                             requestMode: {
                                 enabled: true, /* enable cmcdv2 request mode */
-                                mode: CMCD_MODE_HEADER, /*overrides global mode */
+                                mode: CMCD_MODE_HEADER, /* overrides global mode */
                             },
                             responseMode: {
-                                enabled: false, /* enable cmcdv2 response mode */
-                                mode: CMCD_MODE_QUERY, /*overrides global mode */
+                                enabled: true, /* enable cmcdv2 response mode. FALSE by default */
+                                mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
                                 enabledKeys: ['br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
-                                requestHeaders: {} /*optional, additional headers for report request */
+                                requestHeaders: {} /* optional, additional headers for report request */
                             },
                             stateIntervalMode: {
-                                enabled: true,
-                                mode: CMCD_MODE_QUERY,
-                                interval: 10000,
-                                requestUrl: 'http://localhost:3000/cmcd_server',
-                                requestMethod: 'POST',
-                                enabledKeys: ['v']
+                                enabled: true, /* enable cmcdv2 state-interval mode. FALSE by default */
+                                mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
+                                interval: 10000,  /* time in ms between regular requests. Default 30s or 0 to omit */
+                                enabledKeys: ['v', 'url'], /* optional, overrides global keys */
+                                requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
+                                requestMethod: 'POST',  /* optional, get by default */
                             }
                         },
                         sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5', /* session id send with each request */

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -56,16 +56,16 @@
                             responseMode: {
                                 enabled: true, /* enable cmcdv2 response mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
-                                enabledKeys: ['br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
-                                requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
+                                enabledKeys: ['sid', 'cid', 'br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
+                                requestUrl: 'http://localhost:3000/cmcd_response_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
                             },
                             stateIntervalMode: {
                                 enabled: true, /* enable cmcdv2 state-interval mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
                                 interval: 10000,  /* time in ms between regular requests. Default 30s or 0 to omit */
-                                enabledKeys: ['v', 'url'], /* optional, overrides global keys */
-                                requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
+                                enabledKeys: ['sid', 'v', 'sf'], /* optional, overrides global keys */
+                                requestUrl: 'http://localhost:3000/cmcd_state_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST',  /* optional, get by default */
                             }
                         },

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -54,12 +54,20 @@
                                 mode: CMCD_MODE_HEADER, /*overrides global mode */
                             },
                             responseMode: {
-                                enabled: true, /* enable cmcdv2 response mode */
+                                enabled: false, /* enable cmcdv2 response mode */
                                 mode: CMCD_MODE_QUERY, /*overrides global mode */
                                 enabledKeys: ['br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
                                 requestHeaders: {} /*optional, additional headers for report request */
+                            },
+                            stateIntervalMode: {
+                                enabled: true,
+                                mode: CMCD_MODE_QUERY,
+                                interval: 10000,
+                                requestUrl: 'http://localhost:3000/cmcd_server',
+                                requestMethod: 'POST',
+                                enabledKeys: ['v']
                             }
                         },
                         sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5', /* session id send with each request */

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -59,7 +59,6 @@
                                 enabledKeys: ['br', 'd', 'ot', 'tb'], /*optional, overrides global keys */
                                 requestUrl: 'http://localhost:3000/cmcd_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST', /*optional, get by default */
-                                requestHeaders: {} /* optional, additional headers for report request */
                             },
                             stateIntervalMode: {
                                 enabled: true, /* enable cmcdv2 state-interval mode. FALSE by default */

--- a/samples/advanced/cmcd.html
+++ b/samples/advanced/cmcd.html
@@ -64,7 +64,7 @@
                                 enabled: true, /* enable cmcdv2 state-interval mode. FALSE by default */
                                 mode: CMCD_MODE_HEADER, /*overrides global mode. JSON not supported */
                                 interval: 10000,  /* time in ms between regular requests. Default 30s or 0 to omit */
-                                enabledKeys: ['sta', 'sid', 'cid', 'sf', 'v'], /* Currently only supports: 'sta', 'sid', 'cid', 'sf', 'v', 'lb', 'pr' */
+                                enabledKeys: ['sta', 'sid', 'cid', 'sf', 'v', 'ltc', 'msd'], /* Currently only supports: 'sta', 'ts', 'sid', 'cid', 'sf', 'v', 'lb', 'pr' */
                                 requestUrl: 'http://localhost:3000/cmcd_state_server', /*mandatory, URL to send report */
                                 requestMethod: 'POST',  /* optional, get by default */
                             }

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -1312,8 +1312,7 @@ function Settings() {
                         mode: null,
                         enabledKeys: null,
                         requestUrl: 'http://localhost:3000/cmcd_server',
-                        requestMethod: 'POST',
-                        requestHeaders: {}
+                        requestMethod: 'POST'
                     },
                     stateIntervalMode: {
                         enabled: false,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -1314,6 +1314,14 @@ function Settings() {
                         requestUrl: 'http://localhost:3000/cmcd_server',
                         requestMethod: 'POST',
                         requestHeaders: {}
+                    },
+                    stateIntervalMode: {
+                        enabled: false,
+                        mode: null,
+                        interval: 30000,
+                        requestUrl: 'http://localhost:3000/cmcd_server',
+                        requestMethod: 'POST',
+                        enabledKeys: null
                     }
                 }
             },

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -1314,6 +1314,13 @@ function Settings() {
                         requestUrl: 'http://localhost:3000/cmcd_server',
                         requestMethod: 'POST',
                         requestHeaders: {}
+                    },
+                    stateIntervalMode: {
+                        enabled: false,
+                        interval: 30000,
+                        requestUrl: 'http://localhost:3000/cmcd_server',
+                        requestMethod: 'POST',
+                        enabledKeys: null
                     }
                 }
             },

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -1314,13 +1314,6 @@ function Settings() {
                         requestUrl: 'http://localhost:3000/cmcd_server',
                         requestMethod: 'POST',
                         requestHeaders: {}
-                    },
-                    stateIntervalMode: {
-                        enabled: false,
-                        interval: 30000,
-                        requestUrl: 'http://localhost:3000/cmcd_server',
-                        requestMethod: 'POST',
-                        enabledKeys: null
                     }
                 }
             },

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -220,7 +220,7 @@ export default {
      *  @memberof Constants#
      *  @static
      */
-    CMCD_AVAILABLE_KEYS: ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v', 'ts', 'url'],
+    CMCD_AVAILABLE_KEYS: ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v', 'ts', 'url', 'sta'],
 
     /**
      *  @constant {string} CMCD_AVAILABLE_REQUESTS specifies all the availables requests type for CMCD metrics.

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -227,8 +227,9 @@ export default {
      *  @memberof Constants#
      *  @static
      *  TODO: Confirm keys and create CMCD AVAILABLE KEYS arrays for CMCD v2 and Response Mode
+     *  TODO: Add support for more keys
      */
-    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'sid', 'cid', 'sf', 'st', 'v', 'ts', 'mtp', 'msd', 'lb', 'tb', 'tab', 'lab'],
+    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'sid', 'cid', 'sf', 'v', 'lb', 'pr'],
 
     /**
      *  @constant {string} CMCD_AVAILABLE_REQUESTS specifies all the availables requests type for CMCD metrics.

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -223,6 +223,14 @@ export default {
     CMCD_AVAILABLE_KEYS: ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v', 'ts', 'url', 'sta'],
 
     /**
+     *  @constant {string} CMCD_AVAILABLE_KEYS_STATE_INTERVAL specifies all the availables keys for the State-Interval Mode of CMCD v2.
+     *  @memberof Constants#
+     *  @static
+     *  TODO: Confirm keys and create CMCD AVAILABLE KEYS arrays for CMCD v2 and Response Mode
+     */
+    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'sid', 'sf', 'st', 'v', 'ts', 'mtp', 'msd', 'lb', 'tb', 'tab', 'lab'],
+
+    /**
      *  @constant {string} CMCD_AVAILABLE_REQUESTS specifies all the availables requests type for CMCD metrics.
      *  @memberof Constants#
      *  @static

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -220,7 +220,7 @@ export default {
      *  @memberof Constants#
      *  @static
      */
-    CMCD_AVAILABLE_KEYS: ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v', 'ts', 'url', 'sta'],
+    CMCD_AVAILABLE_KEYS: ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v', 'ts', 'url', 'sta', 'ltc', 'msd'],
 
     /**
      *  @constant {string} CMCD_AVAILABLE_KEYS_STATE_INTERVAL specifies all the availables keys for the State-Interval Mode of CMCD v2.
@@ -229,7 +229,7 @@ export default {
      *  TODO: Confirm keys and create CMCD AVAILABLE KEYS arrays for CMCD v2 and Response Mode
      *  TODO: Add support for more keys
      */
-    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'sid', 'cid', 'sf', 'v', 'lb', 'pr'],
+    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'ts', 'sid', 'cid', 'sf', 'v', 'lb', 'pr', 'ltc', 'msd'],
 
     /**
      *  @constant {string} CMCD_AVAILABLE_REQUESTS specifies all the availables requests type for CMCD metrics.

--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -228,7 +228,7 @@ export default {
      *  @static
      *  TODO: Confirm keys and create CMCD AVAILABLE KEYS arrays for CMCD v2 and Response Mode
      */
-    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'sid', 'sf', 'st', 'v', 'ts', 'mtp', 'msd', 'lb', 'tb', 'tab', 'lab'],
+    CMCD_AVAILABLE_KEYS_STATE_INTERVAL: ['sta', 'sid', 'cid', 'sf', 'st', 'v', 'ts', 'mtp', 'msd', 'lb', 'tb', 'tab', 'lab'],
 
     /**
      *  @constant {string} CMCD_AVAILABLE_REQUESTS specifies all the availables requests type for CMCD metrics.

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -154,7 +154,7 @@ function CmcdModel() {
     }
 
     function _sendCmcdStateIntervalData(state, cmcdStateIntervalMode) {
-        const cmcdData = _getStateIntervalCmcdData(state);
+        const cmcdData = _getGenericCmcdData(null, state);
         const filteredCmcdData = _applyWhitelist(cmcdData, 3);
 
         var requestUrl = cmcdStateIntervalMode.requestUrl;
@@ -593,9 +593,13 @@ function CmcdModel() {
     }
 
 
-    function _getGenericCmcdData(request) {
+    function _getGenericCmcdData(request, playerState = null) {
         const cmcdParametersFromManifest = getCmcdParametersFromManifest();
         const data = {};
+
+        if (playerState) {
+            data.sta = playerState;
+        }
 
         let cid = settings.get().streaming.cmcd.cid ? settings.get().streaming.cmcd.cid : internalData.cid;
         cid = cmcdParametersFromManifest.contentID ? cmcdParametersFromManifest.contentID : cid;
@@ -625,45 +629,10 @@ function CmcdModel() {
 
         // Add v2 mandatory keys
         const cmcdResponseMode = settings.get().streaming.cmcd.reporting.responseMode;
-        if (internalData.v === 2 && cmcdResponseMode.enabled) {
+        if (request && internalData.v === 2 && cmcdResponseMode.enabled) {
             data.url = request.url.split('?')[0]; // remove potential cmcd query params 
             // TODO: This key needs to be generated when loading the media request in _loadRequest
             data.ts = Date.now();
-        }
-
-        return data;
-    }
-
-    function _getStateIntervalCmcdData(state) {
-        const data = {};
-
-        // Adds mandatory state key
-        if (state) {
-            data.sta = state;
-        }
-
-        let cid = settings.get().streaming.cmcd.cid ? settings.get().streaming.cmcd.cid : internalData.cid;
-
-        data.v = internalData.v === 2 ? 2 : CMCD_VERSION;
-
-        data.sid = settings.get().streaming.cmcd.sid ? settings.get().streaming.cmcd.sid : internalData.sid;
-
-        data.sid = `${data.sid}`;
-
-        if (cid) {
-            data.cid = `${cid}`;
-        }
-
-        if (!isNaN(internalData.pr) && internalData.pr !== 1 && internalData.pr !== null) {
-            data.pr = internalData.pr;
-        }
-
-        if (internalData.st) {
-            data.st = internalData.st;
-        }
-
-        if (internalData.sf) {
-            data.sf = internalData.sf;
         }
 
         return data;

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -86,8 +86,12 @@ function CmcdModel() {
         eventBus.on(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.on(MediaPlayerEvents.PLAYBACK_SEEKED, _onPlaybackSeeked, instance);
         eventBus.on(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED, _onPeriodSwitchComplete, instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_INITIALIZED, () => _onStateChange('starting'), instance);
         eventBus.on(MediaPlayerEvents.PLAYBACK_PLAYING, () => _onStateChange('playing'), instance);
         eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('paused'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('seeking'), instance);
+        eventBus.on(MediaPlayerEvents.BUFFER_EMPTY, () => _onStateChange('rebuffering'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_ERROR, () => _onStateChange('error'), instance);
         
         const cmcdStateIntervalMode = _getCmcdStateIntervalData();
         if (cmcdStateIntervalMode){

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -65,9 +65,6 @@ function CmcdModel() {
         _isStartup,
         _bufferLevelStarved,
         _initialMediaRequestsDone;
-    
-    let stateIntervalData = [];
-    let stateIntervalTimer = null;
 
     let context = this.context;
     let eventBus = EventBus(context).getInstance();
@@ -86,9 +83,6 @@ function CmcdModel() {
         eventBus.on(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.on(MediaPlayerEvents.PLAYBACK_SEEKED, _onPlaybackSeeked, instance);
         eventBus.on(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED, _onPeriodSwitchComplete, instance);
-        // TODO: Add more player states
-        eventBus.on(MediaPlayerEvents.PLAYBACK_PLAYING, () => _onStateChange('playing'), instance);
-        eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('paused'), instance);
     }
 
     function setConfig(config) {
@@ -201,9 +195,6 @@ function CmcdModel() {
                         enabledCMCDKeys.push(key);
                     }
                 });
-            } else if (cmcdReportingMode === 3) {
-                enabledCMCDKeys = settings.get().streaming.cmcd.reporting.stateIntervalMode.enabledKeys ? settings.get().streaming.cmcd.reporting.stateIntervalMode.enabledKeys : settings.get().streaming.cmcd.enabledKeys;
-                // TODO: Add required keys
             }
             return Object.keys(cmcdData)
                 .filter(key => enabledCMCDKeys.includes(key))
@@ -215,74 +206,6 @@ function CmcdModel() {
             return cmcdData;
         }
     }
-
-    function handleStateIntervalData(request) {
-        try {
-            if (isCmcdEnabled()) {
-                const cmcdData = getCmcdData(request);
-                const filteredCmcdData = _applyWhitelist(cmcdData, 3);
-                if (filteredCmcdData) {
-                    stateIntervalData.push(filteredCmcdData);
-                }
-                if (!stateIntervalTimer) {
-                    stateIntervalTimer = setTimeout(_sendStateIntervalData, settings.get().streaming.cmcd.reporting.stateIntervalMode.interval);
-                }
-            }
-        } catch (e) {
-            return null;
-        }
-    }
-
-    function _sendStateIntervalData() {
-        const cmcdStateIntervalMode = settings.get().streaming.cmcd.reporting.stateIntervalMode;
-        if (cmcdStateIntervalMode.enabled && stateIntervalData.length > 0) {
-            const aggregatedData = _mergeCmcdData(stateIntervalData);
-
-            // TODO: Check mandatory keys
-            const payload = {
-                ts: Date.now(),
-                cmcdData: aggregatedData // Array of CMCD data objects
-            };
-    
-            fetch(cmcdStateIntervalMode.requestUrl, {
-                method: cmcdStateIntervalMode.requestMethod,
-                headers: {
-                    ...cmcdStateIntervalMode.requestHeaders,
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(payload)
-            }).then(response => {
-                console.log('State-interval CMCD data sent successfully:', response);
-            }).catch(error => {
-                console.error('Error sending state-interval CMCD data:', error);
-            }).finally(() => {
-                stateIntervalData = []; // Reset the data array
-                stateIntervalTimer = null; // Clear the timer
-            });
-        }
-    }
-
-    function _mergeCmcdData(dataArray) {
-        // TODO: Map configured keys
-        return dataArray.
-            filter(data => Object.keys(data).length > 0).
-            map(data => {
-                return {
-                    br: data.br,
-                    d: data.d,
-                    ot: data.ot,
-                    tb: data.tb,
-                };
-            });
-    }
-
-    function _onStateChange(state) {
-        console.log(`Player state changed to: ${state}`)
-        const stateData = { sta: state, ts: Date.now() };
-        stateIntervalData.push(stateData);
-        _sendStateIntervalData();
-    }
-    
 
     function getHeaderParameters(request, triggerEvent = true, cmcdReportingMode = null) {
         try {
@@ -793,8 +716,7 @@ function CmcdModel() {
         eventBus.off(MediaPlayerEvents.MANIFEST_LOADED, _onManifestLoaded, this);
         eventBus.off(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.off(MediaPlayerEvents.PLAYBACK_SEEKED, _onPlaybackSeeked, instance);
-        eventBus.off(MediaPlayerEvents.PLAYBACK_PLAYING, () => _onStateChange('playing'), instance);
-        eventBus.off(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('paused'), instance);
+
         _resetInitialSettings();
     }
 
@@ -807,7 +729,6 @@ function CmcdModel() {
         reset,
         initialize,
         isCmcdEnabled,
-        handleStateIntervalData
     };
 
     setup();

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -264,6 +264,8 @@ function CmcdModel() {
                 });
             } else if (cmcdReportingMode === 3) {
                 enabledCMCDKeys = settings.get().streaming.cmcd.reporting.stateIntervalMode.enabledKeys ? settings.get().streaming.cmcd.reporting.stateIntervalMode.enabledKeys : settings.get().streaming.cmcd.enabledKeys;
+                // Remove unsupported State-Interval mode keys
+                enabledCMCDKeys = enabledCMCDKeys.filter(key => Constants.CMCD_AVAILABLE_KEYS_STATE_INTERVAL.includes(key));
                 // Add CMCD v2 State-interval mode mandatory keys
                 const requiredKeys = ['sta'];
                 requiredKeys.forEach(key => {

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -181,7 +181,7 @@ function CmcdModel() {
 
     function _startCmcdStateIntervalTimer(interval, stateIntervalMode) {
         intervalTimer = setTimeout(() => {
-            _sendCmcdStateIntervalData(interval, stateIntervalMode)
+            _sendCmcdStateIntervalData(null, stateIntervalMode)
             // Restart the timer
             _startCmcdStateIntervalTimer(interval, stateIntervalMode);
         }, interval); 
@@ -631,7 +631,9 @@ function CmcdModel() {
         const data = {};
 
         // Adds mandatory state key
-        data.sta = state;
+        if (state) {
+            data.sta = state;
+        }
 
         let cid = settings.get().streaming.cmcd.cid ? settings.get().streaming.cmcd.cid : internalData.cid;
 

--- a/src/streaming/models/CmcdModel.js
+++ b/src/streaming/models/CmcdModel.js
@@ -84,12 +84,12 @@ function CmcdModel() {
         eventBus.on(MediaPlayerEvents.BUFFER_LEVEL_STATE_CHANGED, _onBufferLevelStateChanged, instance);
         eventBus.on(MediaPlayerEvents.PLAYBACK_SEEKED, _onPlaybackSeeked, instance);
         eventBus.on(MediaPlayerEvents.PERIOD_SWITCH_COMPLETED, _onPeriodSwitchComplete, instance);
-        eventBus.on(MediaPlayerEvents.PLAYBACK_INITIALIZED, () => _onStateChange('starting'), instance);
-        eventBus.on(MediaPlayerEvents.PLAYBACK_PLAYING, () => _onStateChange('playing'), instance);
-        eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('paused'), instance);
-        eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('seeking'), instance);
-        eventBus.on(MediaPlayerEvents.BUFFER_EMPTY, () => _onStateChange('rebuffering'), instance);
-        eventBus.on(MediaPlayerEvents.PLAYBACK_ERROR, () => _onStateChange('error'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_INITIALIZED, () => _onStateChange('s'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_PLAYING, () => _onStateChange('p'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, () => _onStateChange('a'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_SEEKING, () => _onStateChange('k'), instance);
+        eventBus.on(MediaPlayerEvents.BUFFER_EMPTY, () => _onStateChange('r'), instance);
+        eventBus.on(MediaPlayerEvents.PLAYBACK_ERROR, () => _onStateChange('e'), instance);
         
         const cmcdStateIntervalMode = _getCmcdStateIntervalData();
         if (cmcdStateIntervalMode){
@@ -148,12 +148,12 @@ function CmcdModel() {
     }
 
     function _onStateChange(state) {
-        if (state === 'starting') {
+        if (state === 's') {
             if (!_playbackStartedTime) {
                 _playbackStartedTime = Date.now()
             }
         }
-        if (state === 'playing') {
+        if (state === 'p') {
             if (!_playbackStartedTime || internalData.msd) {
                 return
             }

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -230,7 +230,7 @@ function HTTPLoader(cfg) {
         const _onRequestEnd = function (aborted = false) {
             if (httpRequest.customData.request.cmcdVersion === 2) {
                 const cmcdResponseMode = httpRequest.customData.request.cmcdResponseMode;
-                if (cmcdResponseMode.enabled){
+                if (cmcdResponseMode && cmcdResponseMode.enabled){
                     fetch(cmcdResponseMode.requestUrl, {
                         method: cmcdResponseMode.requestMethod,
                         headers: cmcdResponseMode.requestHeaders,
@@ -658,7 +658,6 @@ function HTTPLoader(cfg) {
                     }
                 }
             }
-            // TODO: Add State-Interval Mode   
         }
     }
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -230,7 +230,7 @@ function HTTPLoader(cfg) {
         const _onRequestEnd = function (aborted = false) {
             if (httpRequest.customData.request.cmcdVersion === 2) {
                 const cmcdResponseMode = httpRequest.customData.request.cmcdResponseMode;
-                if (cmcdResponseMode.enabled){
+                if (cmcdResponseMode && cmcdResponseMode.enabled){
                     fetch(cmcdResponseMode.requestUrl, {
                         method: cmcdResponseMode.requestMethod,
                         headers: cmcdResponseMode.requestHeaders,
@@ -632,6 +632,7 @@ function HTTPLoader(cfg) {
             } else if (cmcdVersion === 2){
                 const cmcdRequestMode = settings.get().streaming.cmcd.reporting.requestMode;
                 const cmcdResponseMode = settings.get().streaming.cmcd.reporting.responseMode;
+                const stateIntervalMode = settings.get().streaming.cmcd.reporting.stateIntervalMode;
                 // Needs to be called to trigger the CMCD_DATA_GENERATED event only once
                 cmcdModel.getHeaderParameters(request);
 
@@ -657,8 +658,13 @@ function HTTPLoader(cfg) {
                         request.cmcdResponseMode.requestHeaders = { ...cmcdResponseMode.requestHeaders, ...cmcdHeaders};
                     }
                 }
+
+                if (stateIntervalMode.enabled){
+                    // const cmcdMode = cmcdResponseMode.mode ? cmcdResponseMode.mode : settings.get().streaming.cmcd.mode;
+                    // Only JSON mode for now
+                    cmcdModel.handleStateIntervalData(request)
+                }
             }
-            // TODO: Add State-Interval Mode   
         }
     }
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -230,7 +230,7 @@ function HTTPLoader(cfg) {
         const _onRequestEnd = function (aborted = false) {
             if (httpRequest.customData.request.cmcdVersion === 2) {
                 const cmcdResponseMode = httpRequest.customData.request.cmcdResponseMode;
-                if (cmcdResponseMode && cmcdResponseMode.enabled){
+                if (cmcdResponseMode.enabled){
                     fetch(cmcdResponseMode.requestUrl, {
                         method: cmcdResponseMode.requestMethod,
                         headers: cmcdResponseMode.requestHeaders,
@@ -632,7 +632,6 @@ function HTTPLoader(cfg) {
             } else if (cmcdVersion === 2){
                 const cmcdRequestMode = settings.get().streaming.cmcd.reporting.requestMode;
                 const cmcdResponseMode = settings.get().streaming.cmcd.reporting.responseMode;
-                const stateIntervalMode = settings.get().streaming.cmcd.reporting.stateIntervalMode;
                 // Needs to be called to trigger the CMCD_DATA_GENERATED event only once
                 cmcdModel.getHeaderParameters(request);
 
@@ -658,13 +657,8 @@ function HTTPLoader(cfg) {
                         request.cmcdResponseMode.requestHeaders = { ...cmcdResponseMode.requestHeaders, ...cmcdHeaders};
                     }
                 }
-
-                if (stateIntervalMode.enabled){
-                    // const cmcdMode = cmcdResponseMode.mode ? cmcdResponseMode.mode : settings.get().streaming.cmcd.mode;
-                    // Only JSON mode for now
-                    cmcdModel.handleStateIntervalData(request)
-                }
             }
+            // TODO: Add State-Interval Mode   
         }
     }
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -654,7 +654,7 @@ function HTTPLoader(cfg) {
                         request.cmcdResponseMode.requestUrl = Utils.addAditionalQueryParameterToUrl(cmcdResponseMode.requestUrl, additionalQueryParameter);
                     } else if (cmcdMode === Constants.CMCD_MODE_HEADER){
                         const cmcdHeaders = cmcdModel.getHeaderParameters(request, false, 2);
-                        request.cmcdResponseMode.requestHeaders = { ...cmcdResponseMode.requestHeaders, ...cmcdHeaders};
+                        request.cmcdResponseMode.requestHeaders = cmcdHeaders;
                     }
                 }
             }


### PR DESCRIPTION
Implemented cmcd v2 State-Interval mode. Currently, only the following keys are supported: ['sta', 'sid', 'cid', 'sf', 'v', 'lb', 'pr']

