### PR TITLE
[ValidiyExpiration] Update the manifest when the InbandEventStream value attribute is three

### DIFF
--- a/src/core/events/CoreEvents.js
+++ b/src/core/events/CoreEvents.js
@@ -60,6 +60,7 @@ class CoreEvents extends EventsBase {
         this.LOADING_DATA_PROGRESS = 'loadingDataProgress';
         this.LOADING_ABANDONED = 'loadingAborted';
         this.MANIFEST_UPDATED = 'manifestUpdated';
+        this.MPD_EXPIRE_UPDATE = 'mpdExpireUpdate';
         this.MEDIA_FRAGMENT_LOADED = 'mediaFragmentLoaded';
         this.MEDIA_FRAGMENT_NEEDED = 'mediaFragmentNeeded';
         this.MEDIAINFO_UPDATED = 'mediaInfoUpdated';

--- a/src/dash/DashAdapter.js
+++ b/src/dash/DashAdapter.js
@@ -40,6 +40,7 @@ import PatchManifestModel from './models/PatchManifestModel.js';
 import Representation from './vo/Representation.js';
 import {bcp47Normalize} from 'bcp-47-normalize';
 import {getId3Frames} from '@svta/common-media-library/id3/getId3Frames.js';
+import {utf8ArrayToStr} from '@svta/common-media-library/utils/utf8ArrayToStr'
 import Constants from '../streaming/constants/Constants.js';
 
 /**
@@ -505,8 +506,11 @@ function DashAdapter() {
             event.calculatedPresentationTime = calculatedPresentationTime;
             event.messageData = messageData;
             event.presentationTimeDelta = presentationTimeDelta;
-            event.parsedMessageData = (schemeIdUri === Constants.ID3_SCHEME_ID_URI) ? getId3Frames(messageData) : null;
-
+            if (schemeIdUri === Constants.ID3_SCHEME_ID_URI) {
+                event.parsedMessageData = getId3Frames(messageData);
+            } else {
+                event.parsedMessageData = (messageData instanceof Uint8Array) ? utf8ArrayToStr(messageData) : null;
+            }
             return event;
         } catch (e) {
             return null;

--- a/src/streaming/ManifestLoader.js
+++ b/src/streaming/ManifestLoader.js
@@ -43,7 +43,6 @@ import FactoryMaker from '../core/FactoryMaker.js';
 import DashParser from '../dash/parser/DashParser.js';
 
 function ManifestLoader(config) {
-
     config = config || {};
     const context = this.context;
     const debug = config.debug;
@@ -59,10 +58,12 @@ function ManifestLoader(config) {
 
     let mssHandler = config.mssHandler;
     let errHandler = config.errHandler;
+    let manifestModel = config.manifestModel;
 
     function setup() {
         logger = debug.getLogger(instance);
         eventBus.on(Events.XLINK_READY, onXlinkReady, instance);
+        eventBus.on(Events.MPD_EXPIRE_UPDATE, updateManifest, instance);
 
         urlLoader = URLLoader(context).create({
             errHandler: config.errHandler,
@@ -247,6 +248,79 @@ function ManifestLoader(config) {
                 });
             }
         });
+    }
+
+    function updateManifest(e) {
+        // Manage situations in which success is called after calling reset
+        if (!xlinkController) {
+            return;
+        }
+        const strManifest = e.xmlString
+        let currentManifest = manifestModel.getValue();
+        let manifest;
+
+        // Create parser according to manifest type
+        parser = createParser(strManifest);
+
+        if (parser === null) {
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+                manifest: null,
+                error: new DashJSError(
+                    Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE,
+                )
+            });
+            return;
+        }
+        // init xlinkcontroller with created parser
+        xlinkController.setParser(parser);
+
+        try {
+            manifest = parser.parse(strManifest);
+        } catch (e) {
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+                manifest: null,
+                error: new DashJSError(
+                    Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE,
+                )
+            });
+            return;
+        }
+
+        if (manifest) {
+            manifest.url = currentManifest.url; 
+
+            // URL from which the MPD was originally retrieved (MPD updates will not change this value)
+            if (!manifest.originalUrl) {
+                manifest.originalUrl = manifest.url;
+            }
+
+            // If there is a mismatch between the manifest's specified duration and the total duration of all periods,
+            // and the specified duration is greater than the total duration of all periods,
+            // overwrite the manifest's duration attribute. This is a patch for if a manifest is generated incorrectly.
+            if (settings &&
+                settings.get().streaming.enableManifestDurationMismatchFix &&
+                manifest.mediaPresentationDuration &&
+                manifest.Period.length > 1) {
+                const sumPeriodDurations = manifest.Period.reduce((totalDuration, period) => totalDuration + period.duration, 0);
+                if (!isNaN(sumPeriodDurations) && manifest.mediaPresentationDuration > sumPeriodDurations) {
+                    logger.warn('Media presentation duration greater than duration of all periods. Setting duration to total period duration');
+                    manifest.mediaPresentationDuration = sumPeriodDurations;
+                }
+            }
+
+            // manifest.baseUri = baseUri;
+            manifest.loadedTime = new Date();
+            xlinkController.resolveManifestOnLoad(manifest);
+
+            eventBus.trigger(Events.ORIGINAL_MANIFEST_LOADED, { originalManifest: e.xmlString });
+        } else {
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, {
+                manifest: null,
+                error: new DashJSError(
+                    Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE,
+                )
+            });
+        }
     }
 
     function reset() {

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -131,6 +131,10 @@ function ManifestUpdater() {
         }
     }
 
+    function patchManifest(manifestPatch) {
+        logger.debug(`Not supported yet ${manifestPatch}`);
+    }
+
     function startManifestRefreshTimer(delay) {
         stopManifestRefreshTimer();
 
@@ -185,6 +189,14 @@ function ManifestUpdater() {
         }
 
         manifestLoader.load(url, serviceLocation, queryParams);
+    }
+
+    function updateManifest (manifest) {
+        // TODO: Parse manifest if needed
+        const event = {
+            manifest
+        }
+        onManifestLoaded(event)   
     }
 
     function _getAvailableMpdLocations(manifest) {
@@ -304,12 +316,14 @@ function ManifestUpdater() {
     }
 
     instance = {
+        getIsUpdating,
         initialize,
+        patchManifest,
+        setConfig,
         setManifest,
         refreshManifest,
-        getIsUpdating,
-        setConfig,
-        reset
+        reset,
+        updateManifest,
     };
 
     setup();

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -58,7 +58,8 @@ function ManifestUpdater() {
         adapter,
         errHandler,
         contentSteeringController,
-        settings;
+        settings,
+        refreshDisabled;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -100,6 +101,7 @@ function ManifestUpdater() {
         eventBus.on(MediaPlayerEvents.PLAYBACK_STARTED, onPlaybackStarted, this);
         eventBus.on(MediaPlayerEvents.PLAYBACK_PAUSED, onPlaybackPaused, this);
         eventBus.on(Events.INTERNAL_MANIFEST_LOADED, onManifestLoaded, this);
+        eventBus.on(MediaPlayerEvents.MANIFEST_VALIDITY_CHANGED, onManifestValidityChanged, this)
     }
 
     function setManifest(manifest) {
@@ -142,7 +144,7 @@ function ManifestUpdater() {
             delay = refreshDelay * 1000;
         }
 
-        if (!isNaN(delay)) {
+        if (!isNaN(delay) && !refreshDisabled) {
             logger.debug('Refresh manifest in ' + delay + ' milliseconds.');
             refreshTimer = setTimeout(onRefreshTimer, delay);
         }
@@ -278,6 +280,14 @@ function ManifestUpdater() {
             update(e.manifest);
         } else if (e.error.code === Errors.MANIFEST_LOADER_PARSING_FAILURE_ERROR_CODE) {
             errHandler.error(e.error);
+        }
+    }
+
+    function onManifestValidityChanged(e) {
+        const { minimumUpdatePeriod } = manifestModel.getValue();
+        if (minimumUpdatePeriod === 0 && e.inbandEvent) {
+            stopManifestRefreshTimer();
+            refreshDisabled = true;
         }
     }
 

--- a/src/streaming/ManifestUpdater.js
+++ b/src/streaming/ManifestUpdater.js
@@ -131,10 +131,6 @@ function ManifestUpdater() {
         }
     }
 
-    function patchManifest(manifestPatch) {
-        logger.debug(`Not supported yet ${manifestPatch}`);
-    }
-
     function startManifestRefreshTimer(delay) {
         stopManifestRefreshTimer();
 
@@ -189,14 +185,6 @@ function ManifestUpdater() {
         }
 
         manifestLoader.load(url, serviceLocation, queryParams);
-    }
-
-    function updateManifest (manifest) {
-        // TODO: Parse manifest if needed
-        const event = {
-            manifest
-        }
-        onManifestLoaded(event)   
     }
 
     function _getAvailableMpdLocations(manifest) {
@@ -318,12 +306,10 @@ function ManifestUpdater() {
     instance = {
         getIsUpdating,
         initialize,
-        patchManifest,
         setConfig,
         setManifest,
         refreshManifest,
         reset,
-        updateManifest,
     };
 
     setup();

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2490,12 +2490,13 @@ function MediaPlayer() {
 
     function _createManifestLoader() {
         return ManifestLoader(context).create({
-            debug: debug,
-            errHandler: errHandler,
-            dashMetrics: dashMetrics,
-            mediaPlayerModel: mediaPlayerModel,
-            mssHandler: mssHandler,
-            settings: settings
+            debug,
+            errHandler,
+            dashMetrics,
+            mediaPlayerModel,
+            mssHandler,
+            manifestModel,
+            settings
         });
     }
 

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -31,6 +31,7 @@
 
 import FactoryMaker from '../../core/FactoryMaker.js';
 import Debug from '../../core/Debug.js';
+import Events from '../core/events/Events.js';
 import EventBus from '../../core/EventBus.js';
 import MediaPlayerEvents from '../../streaming/MediaPlayerEvents.js';
 import XHRLoader from '../net/XHRLoader.js';
@@ -265,7 +266,7 @@ function EventController() {
 
                     if (result === EVENT_HANDLED_STATES.ADDED) {
                         if (event.eventStream.schemeIdUri === MPD_VALIDITY_EXPIRATION_SCHEME) {
-                            _handleManifestReloadEvent(event);
+                            _handleManifestReload(event);
                         }
                         logger.debug(`Added inband event with id ${event.id} from period ${periodId}`);
                         _startEvent(event, MediaPlayerEvents.EVENT_MODE_ON_RECEIVE);
@@ -327,7 +328,7 @@ function EventController() {
      * @param {object} event
      * @private
      */
-    function _handleManifestExiration(event, currentVideoTime) {
+    function _handleManifestValidityExpirationEvent(event, currentVideoTime) {
         switch (event.eventStream.value) {
             case MPD_RELOAD_VALUE:
                 logger.debug(`Starting manifest refresh event ${event.id} at ${currentVideoTime}`);
@@ -348,7 +349,7 @@ function EventController() {
      * @param {object} event
      * @private
      */
-    function _handleManifestReloadEvent(event) {
+    function _handleManifestReload(event) {
         try {
             const validUntil = event.calculatedPresentationTime;
             let newDuration;
@@ -503,7 +504,7 @@ function EventController() {
                 if (event.eventStream.schemeIdUri === MPD_VALIDITY_EXPIRATION_SCHEME) {
                     //If both are set to zero, it indicates the media is over at this point. Don't reload the manifest.
                     if (event.duration !== 0 || event.presentationTimeDelta !== 0) {
-                        _handleManifestExiration(event, currentVideoTime)
+                        _handleManifestValidityExpirationEvent(event, currentVideoTime)
                     }
                 } else if (event.eventStream.schemeIdUri === MPD_CALLBACK_SCHEME && event.eventStream.value == MPD_CALLBACK_VALUE) {
                     logger.debug(`Starting callback event ${eventId} at ${currentVideoTime}`);
@@ -564,7 +565,11 @@ function EventController() {
     function _patchManifest(manifestPatch) {
         try {
             checkConfig();
-            manifestUpdater.patchManifest(manifestPatch);
+            const event = {
+                manifest: manifestPatch // Parse manifest before assigne
+            }
+            logger.debug(`Patch manifest not supported yet ${event}`);
+            // eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { event });
         } catch (e) {
             logger.error(e);
         }
@@ -577,7 +582,10 @@ function EventController() {
     function _updateManifest(manifest) {
         try {
             checkConfig();
-            manifestUpdater.updateManifest(manifest);
+            const event = {
+                manifest // Parse manifest before assigne
+            }
+            eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { event });
         } catch (e) {
             logger.error(e);
         }


### PR DESCRIPTION
The schemeIdUri `urn:mpeg:dash:event:2012` is used to identify an `InbandEventStream` with an attribute value of 1 (MPD validity expiration), 2 (MPD Patch), or 3 (MPD Update).

MPD validity expiration events provide the ability to signal to the client that the MPD with a specific publish time can only be used up to a certain media presentation time. In the case of MPD Update events, a complete MPD shall be included in the in the DASHEvent structure, immediately following the publish_time field. The content of the mpd field shall be the MPD.