### PR TITLE
cmcdv2/e key implementation

### DIFF
--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -263,10 +263,9 @@ export default {
         SEEKING: 'k',
         REBUFFERING: 'r',
         FATAL_ERROR: 'f',
-        ENDED: 'e',
+        ERROR: 'e',
         TIME_INTERVAL: 't'
     },
-
     INITIALIZE: 'initialize',
     TEXT_SHOWING: 'showing',
     TEXT_HIDDEN: 'hidden',

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -246,7 +246,6 @@ function CmcdController() {
     }
 
     function _onPlayerError(errorData) {
-        debugger;
         const errorCode = errorData.error.code ? errorData.error.code : 0
         internalData.ec = errorCode;
         _onStateChange(Constants.CMCD_REPORTING_EVENTS.ERROR);

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -115,11 +115,11 @@ function CmcdController() {
             [MediaPlayerEvents.PLAYBACK_PAUSED]: Constants.CMCD_REPORTING_EVENTS.PAUSED,
             [MediaPlayerEvents.PLAYBACK_PLAYING]: Constants.CMCD_REPORTING_EVENTS.PLAYING,
             [MediaPlayerEvents.PLAYBACK_ERROR]: Constants.CMCD_REPORTING_EVENTS.FATAL_ERROR,
-            [MediaPlayerEvents.PLAYBACK_ENDED]: Constants.CMCD_REPORTING_EVENTS.ENDED
         };
 
         eventBus.on(MediaPlayerEvents.PLAYBACK_SEEKING, _onPlaybackSeeking, instance);
         eventBus.on(MediaPlayerEvents.PLAYBACK_WAITING, _onPlaybackWaiting, instance);
+        eventBus.on(MediaPlayerEvents.ERROR, _onPlayerError, instance);
     
         Object.entries(eventStateMap).forEach(([event, state]) => {
             eventBus.on(event, () => _onStateChange(state), instance);
@@ -148,6 +148,10 @@ function CmcdController() {
         
         const cmcdData = _getGenericCmcdData();
         cmcdData.e = state;
+        
+        if (state == 'e') {
+            cmcdData.ec = internalData.ec;
+        }
 
         eventModeTargets.forEach(targetSettings => {
             if (targetSettings.enabled) {
@@ -239,6 +243,13 @@ function CmcdController() {
         }
 
         internalData.msd = Date.now() - _playbackStartedTime;
+    }
+
+    function _onPlayerError(errorData) {
+        debugger;
+        const errorCode = errorData.error.code ? errorData.error.code : 0
+        internalData.ec = errorCode;
+        _onStateChange(Constants.CMCD_REPORTING_EVENTS.ERROR);
     }
 
     function _updateStreamProcessors() {


### PR DESCRIPTION
Testing config:
```js
// Using an invalid url to generate an error
var video,
	url = 'https://invalid-url.com/manifest.mpd',
	version;

...

player.updateSettings({
	streaming: {
		cmcd: {
			version: 2,
			enabled: false,
			sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5',
			cid: '21cf726cfe3d937b5f974f72bb5bd06a',
			mode: CMCD_MODE_QUERY,
			targets: [
			{
				enabled: true,
				cmcdMode: "event",
				url: "https://localhost:3003/event-mode",
				timeInterval: 10,
				enabledKeys: ['e', 'ec'],
				events: ['e']
			}]
		}
	}
});
```