### PR TITLE
cmcdv2/ts key implementation

### DIFF
--- a/src/streaming/constants/Constants.js
+++ b/src/streaming/constants/Constants.js
@@ -215,6 +215,12 @@ export default {
      */
     CMCD_MODE_HEADER: 'header',
     /**
+     *  @constant {string} CMCD_V2_KEYS_MAPPING
+     *  @memberof Constants#
+     *  @static
+    */
+    CMCD_V2_KEYS_NAME_MAPPING: { EVENT: 'e' },
+    /**
      *  @constant {string} CMCD_MANDATORY_KEYS specifies all the mandatory keys for all CMCD modes (Event Mode, Request Mode & Response Mode).
      *  @memberof Constants#
      *  @static

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -298,8 +298,9 @@ function CmcdController() {
         try {
             const cmcdParametersFromManifest = getCmcdParametersFromManifest();
             let enabledCMCDKeys = enabledKeys || (cmcdParametersFromManifest.version ? cmcdParametersFromManifest.keys : settings.get().streaming.cmcd.enabledKeys);
-
-            if (cmcdData.e) {
+            
+            const events_key = Constants.CMCD_V2_KEYS_NAME_MAPPING.EVENT
+            if (enabledCMCDKeys.includes(events_key) && cmcdData.e) {
                 enabledCMCDKeys = includeEventModeMandatoryKeys(enabledCMCDKeys)
             }
 


### PR DESCRIPTION
Test by updating `enabledKeys=['e']`, then remove the event key (`enabledKeys=[]`) and no `ts` should be sent:
```js
player.updateSettings({
	streaming: {
		cmcd: {
			version: 2,
			enabled: false,
			sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5',
			cid: '21cf726cfe3d937b5f974f72bb5bd06a',
			mode: CMCD_MODE_QUERY,
			targets: [
			{
				enabled: true,
				cmcdMode: "event",
				url: "https://localhost:3003/event-mode",
				timeInterval: 10,
				enabledKeys: ['e']
				events: ['s', 'p', 'k', 'a', 'e', 'r', 'f']
			}]
		}
	}
});
```