### PR TITLE
cmcdv2/cmcdrequest v2 to v1

### DIFF
--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -46,6 +46,7 @@ import {CmcdStreamingFormat} from '@svta/common-media-library/cmcd/CmcdStreaming
 import {encodeCmcd} from '@svta/common-media-library/cmcd/encodeCmcd';
 import {toCmcdHeaders} from '@svta/common-media-library/cmcd/toCmcdHeaders';
 import {CmcdHeaderField} from '@svta/common-media-library/cmcd/CmcdHeaderField';
+import {convertToCmcdV1} from '@svta/common-media-library/cmcd/CmcdV2ToCmcdV1';
 import CmcdReportRequest from '../../streaming/vo/CmcdReportRequest.js';
 
 import URLLoader from '../net/URLLoader.js';
@@ -1011,11 +1012,16 @@ function CmcdController() {
         }
 
         const request = commonMediaRequest.customData.request;
-    
-        const cmcdRequestData = {
+
+        var cmcdRequestData = {
             ...getCmcdData(request),
             ..._updateMsdData(Constants.CMCD_MODE.REQUEST)
         };
+
+        const cmcdVersion = settings.get().streaming.cmcd.version ?? DEFAULT_CMCD_VERSION;
+        if (cmcdVersion === 1) {
+            cmcdRequestData = convertToCmcdV1(cmcdRequestData);
+        }
 
         request.cmcd = cmcdRequestData;
     

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -46,11 +46,15 @@ import {CmcdStreamingFormat} from '@svta/common-media-library/cmcd/CmcdStreaming
 import {encodeCmcd} from '@svta/common-media-library/cmcd/encodeCmcd';
 import {toCmcdHeaders} from '@svta/common-media-library/cmcd/toCmcdHeaders';
 import {CmcdHeaderField} from '@svta/common-media-library/cmcd/CmcdHeaderField';
-import {convertToCmcdV1} from '@svta/common-media-library/cmcd/CmcdV2ToCmcdV1';
+
+
 import CmcdReportRequest from '../../streaming/vo/CmcdReportRequest.js';
 
 import URLLoader from '../net/URLLoader.js';
 import Errors from '../../core/errors/Errors.js';
+
+// TODO: Re-Add this import once common-media-library pr is merged: https://github.com/qualabs/common-media-library/pull/48
+// import {convertToCmcdV1} from '@svta/common-media-library/cmcd/CmcdV2ToCmcdV1';
 
 const DEFAULT_CMCD_VERSION = 1;
 const DEFAULT_INCLUDE_IN_REQUESTS = 'segment';
@@ -1020,7 +1024,10 @@ function CmcdController() {
 
         const cmcdVersion = settings.get().streaming.cmcd.version ?? DEFAULT_CMCD_VERSION;
         if (cmcdVersion === 1) {
-            cmcdRequestData = convertToCmcdV1(cmcdRequestData);
+            // TODO: Re-Add this import once common-media-library pr is merged: https://github.com/qualabs/common-media-library/pull/48
+            // Also remove the temporaryConvertToCmcdV1 line
+            // cmcdRequestData = convertToCmcdV1(cmcdRequestData);
+            cmcdRequestData = temporaryConvertToCmcdV1(cmcdRequestData);
         }
 
         request.cmcd = cmcdRequestData;
@@ -1036,6 +1043,19 @@ function CmcdController() {
         };
 
         return commonMediaRequest;
+    }
+
+    // TODO: delete this once common-media-library pr is merged: https://github.com/qualabs/common-media-library/pull/48
+    function temporaryConvertToCmcdV1(cmcdData) {
+        const result = {};
+        
+        for (const key in cmcdData) {
+            if (Constants.CMCD_AVAILABLE_KEYS.includes(key)) {
+                result[key] = cmcdData[key];
+            }
+        }
+
+        return result;
     }
 
     function _updateMsdData(mode) {

--- a/src/streaming/controllers/CmcdController.js
+++ b/src/streaming/controllers/CmcdController.js
@@ -1017,7 +1017,7 @@ function CmcdController() {
 
         const request = commonMediaRequest.customData.request;
 
-        var cmcdRequestData = {
+        let cmcdRequestData = {
             ...getCmcdData(request),
             ..._updateMsdData(Constants.CMCD_MODE.REQUEST)
         };


### PR DESCRIPTION
Added convertion from v2 to v1 for cmcd request.

>[!Important]
> This branch needs the code in this PR from the common media library:
> - <https://github.com/qualabs/common-media-library/pull/48>
> We need to merget his changes to common media library first

Testing:
With `version: 1`, result should exclude `msd`, include `sid`, `cid`, and `v`
```js
player.updateSettings({
	streaming: {
		cmcd: {
			version: 1,
			enabled: true,
			sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5',
			cid: '21cf726cfe3d937b5f974f72bb5bd06a',
			mode: CMCD_MODE_QUERY,
			enabledKeys: ['msd', 'sid', 'cid', 'v']
		}
	}
});
```

With `version: 2`, result should include all keys
```js
player.updateSettings({
	streaming: {
		cmcd: {
			version: 2,
			enabled: true,
			sid: 'b248658d-1d1a-4039-91d0-8c08ba597da5',
			cid: '21cf726cfe3d937b5f974f72bb5bd06a',
			mode: CMCD_MODE_QUERY,
			enabledKeys: ['msd', 'sid', 'cid', 'v']
		}
	}
});
```