### PR TITLE
executeOnce bugfix

### DIFF
--- a/src/streaming/MediaManager.js
+++ b/src/streaming/MediaManager.js
@@ -114,7 +114,7 @@ function MediaManager() {
 
             // Create a prebuffered player
             const prebufferedPlayer = MediaPlayer().create();
-            prebufferedPlayer.initialize(null, alternativeMpdUrl, false, NaN, alternativeContext);
+            prebufferedPlayer.initialize(null, alternativeMpdUrl, false, NaN, null);
             prebufferedPlayer.updateSettings({
                 streaming: {cacheInitSegments: true}
             });
@@ -194,7 +194,7 @@ function MediaManager() {
                 cacheInitSegments: true
             }
         });
-        altPlayer.initialize(null, alternativeMpdUrl, false, NaN, alternativeContext);
+        altPlayer.initialize(null, alternativeMpdUrl, false, NaN, null);
         altPlayer.preload();
         altPlayer.setAutoPlay(false);
         altPlayer.on(Events.ERROR, onAlternativePlayerError, this);

--- a/src/streaming/MediaManager.js
+++ b/src/streaming/MediaManager.js
@@ -114,7 +114,7 @@ function MediaManager() {
 
             // Create a prebuffered player
             const prebufferedPlayer = MediaPlayer().create();
-            prebufferedPlayer.initialize(null, alternativeMpdUrl, false, NaN, null);
+            prebufferedPlayer.initialize(null, alternativeMpdUrl, false, NaN);
             prebufferedPlayer.updateSettings({
                 streaming: {cacheInitSegments: true}
             });
@@ -194,7 +194,7 @@ function MediaManager() {
                 cacheInitSegments: true
             }
         });
-        altPlayer.initialize(null, alternativeMpdUrl, false, NaN, null);
+        altPlayer.initialize(null, alternativeMpdUrl, false, NaN);
         altPlayer.preload();
         altPlayer.setAutoPlay(false);
         altPlayer.on(Events.ERROR, onAlternativePlayerError, this);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -288,7 +288,7 @@ function MediaPlayer() {
      * @memberof module:MediaPlayer
      * @instance
      */
-    function initialize(view, source, autoPlay, startTime = NaN, alternativeContext = null) {
+    function initialize(view, source, autoPlay, startTime = NaN) {
         if (!capabilities) {
             capabilities = Capabilities(context).getInstance();
             capabilities.setConfig({
@@ -323,7 +323,7 @@ function MediaPlayer() {
             }
 
             if (!alternativeMediaController) {
-                alternativeMediaController = AlternativeMediaController(alternativeContext ? alternativeContext : context).getInstance();
+                alternativeMediaController = AlternativeMediaController(context).getInstance();
             }
 
             if (!playbackController) {


### PR DESCRIPTION
Alternative events were turned off because of the following workflow:

1. MediaManager.initializeAlternativePlayer
2. MediaPlayer.initialize
3. MediaPlayer.attachSource
4. MediaPlayer.reset
5. AlternativeMediaController.reset
